### PR TITLE
Apikey support

### DIFF
--- a/lib/projects/api/API.rb
+++ b/lib/projects/api/API.rb
@@ -8,7 +8,7 @@ module Projects
 			public
 			@@baseURL = "https://projectsapi.zoho.com/restapi/";
 			protected
-			  	attr_accessor :authToken, :portalId
+			  	attr_accessor :authToken, :portalId, :apiKey
 			  	
 			public
 
@@ -20,9 +20,11 @@ module Projects
 				#
 				# * portalId:: - User's portalId.
 
-			  	def initialize(authToken, portalId)
+			  	def initialize(authToken, portalId, apiKey=nil)
+			    	raise ArgumentError, 'authToken is required' if authToken.to_s.empty?
 			    	@authToken = authToken
 			    	@portalId = portalId
+			    	@apiKey = apiKey
 			  	end
 			
 			public
@@ -34,6 +36,7 @@ module Projects
 				# * Base URL.
 
 			 	def getBaseURL
+		  			raise ArgumentError, 'portalId is required' if portalId.to_s.empty?
 		  			return @@baseURL+"portal/"+String(portalId)+"/";
 		  		end
 
@@ -49,6 +52,9 @@ module Projects
 			  		else
 			  			queryMap1 = Hash.new
 		  				queryMap1["authtoken"] = authToken
+			  		end
+		  			if apiKey != nil
+		  				queryMap1["apikey"] = apiKey
 			  		end
 		  		return queryMap1
 		  		end

--- a/lib/projects/api/BugsAPI.rb
+++ b/lib/projects/api/BugsAPI.rb
@@ -34,8 +34,8 @@ module Projects
 			# * portalId:: - User's portalId.
 
 
-			def initialize(authToken,portalId)
-				super(authToken,portalId)
+			def initialize(authToken,portalId,apiKey=nil)
+				super(authToken,portalId,apiKey)
 			end
 
 			# * Get list of bugs for the project.

--- a/lib/projects/api/DocumentsAPI.rb
+++ b/lib/projects/api/DocumentsAPI.rb
@@ -35,8 +35,8 @@ module Projects
 			# * portalId:: - User's portalId.
 
 
-			def initialize(authToken,portalId)
-				super(authToken,portalId)
+			def initialize(authToken,portalId,apiKey=nil)
+				super(authToken,portalId,apiKey)
 			end
 
 

--- a/lib/projects/api/EventsAPI.rb
+++ b/lib/projects/api/EventsAPI.rb
@@ -33,8 +33,8 @@ module Projects
 			# 
 			# * portalId:: - User's portalId.
 
-			def initialize(authToken,portalId)
-				super(authToken,portalId)
+			def initialize(authToken,portalId,apiKey=nil)
+				super(authToken,portalId,apiKey)
 			end
 			
 			# * Get list of events for the project.

--- a/lib/projects/api/FoldersAPI.rb
+++ b/lib/projects/api/FoldersAPI.rb
@@ -33,8 +33,8 @@ module Projects
 			# 
 			# * portalId:: - User's portalId.
 
-			def initialize(authToken,portalId)
-				super(authToken,portalId)
+			def initialize(authToken,portalId,apiKey=nil)
+				super(authToken,portalId,apiKey)
 			end
 
 			# * Get list of folders for the project.

--- a/lib/projects/api/ForumsAPI.rb
+++ b/lib/projects/api/ForumsAPI.rb
@@ -39,9 +39,9 @@ module Projects
 			#
 			# * portalId:: - User's prtalId.
 
-			def initialize(authToken,portalId)
-				super(authToken,portalId)
-			end	
+			def initialize(authToken,portalId,apiKey=nil)
+				super(authToken,portalId,apiKey)
+			end
 
 			# * Get list of forum for the project.
 			# 

--- a/lib/projects/api/MilestonesAPI.rb
+++ b/lib/projects/api/MilestonesAPI.rb
@@ -37,8 +37,8 @@ module Projects
 		 	#
 			# * portalId:: - User's portalId.
 
-			def initialize(authToken,portalId)
-				super(authToken,portalId)
+			def initialize(authToken,portalId,apiKey=nil)
+				super(authToken,portalId,apiKey)
 			end
 
 			# * Get list of milestones for the project.

--- a/lib/projects/api/PortalAPI.rb
+++ b/lib/projects/api/PortalAPI.rb
@@ -19,8 +19,8 @@ module Projects
 			#
 			# * authToken:: - User's authToken.
 
-			def initialize(authToken)
-				super(authToken,"")
+			def initialize(authToken, apiKey=nil)
+				super(authToken,"",apiKey)
 			end
 
 			# * Parse the JSON response into respective objects.

--- a/lib/projects/api/ProjectsAPI.rb
+++ b/lib/projects/api/ProjectsAPI.rb
@@ -36,8 +36,8 @@ module Projects
 			#  
 			# * portalId:: - User's portalId.
 
-			def initialize(authToken,portalId)
-				super(authToken,portalId)
+			def initialize(authToken,portalId,apiKey=nil)
+				super(authToken,portalId,apiKey)
 			end
 
 			# * Get the genearal url for getting all Projects.

--- a/lib/projects/api/TasklistsAPI.rb
+++ b/lib/projects/api/TasklistsAPI.rb
@@ -33,8 +33,8 @@ module Projects
 			# * portalId:: - User's portalId.
 
 
-			def initialize(authToken,portalId)
-				super(authToken,portalId)
+			def initialize(authToken,portalId,apiKey=nil)
+				super(authToken,portalId,apiKey)
 			end
 
 			# * Get list of tasklists for the project.

--- a/lib/projects/api/TasksAPI.rb
+++ b/lib/projects/api/TasksAPI.rb
@@ -35,8 +35,8 @@ module Projects
 			#  
 			# * portalId:: - User's portalId.
 
-			def initialize(authToken,portalId)
-				super(authToken,portalId)
+			def initialize(authToken,portalId,apiKey=nil)
+				super(authToken,portalId,apiKey)
 			end
 
 			# * Get list of tasks for the project.

--- a/lib/projects/api/TimesheetsAPI.rb
+++ b/lib/projects/api/TimesheetsAPI.rb
@@ -44,8 +44,8 @@ module Projects
 			#  
 			# * portalId:: - User's portalId.
 
-			def initialize(authToken,portalId)
-				super(authToken,portalId)
+			def initialize(authToken,portalId,apiKey=nil)
+				super(authToken,portalId,apiKey)
 			end
 			
 			# * Get list of time logs for the project.

--- a/lib/projects/api/UsersAPI.rb
+++ b/lib/projects/api/UsersAPI.rb
@@ -24,8 +24,8 @@ module Projects
 			#  
 			# * portalId:: - User's portalId.
 
-			def initialize(authToken,portalId)
-				super(authToken,portalId)
+			def initialize(authToken,portalId,apiKey=nil)
+				super(authToken,portalId,apiKey)
 			end
 
 			# * Get list of users for the project.

--- a/lib/projects/model/Task.rb
+++ b/lib/projects/model/Task.rb
@@ -6,7 +6,7 @@ module Projects
 		class Task
 
 			private
-				attr_accessor :id, :idString :name, :completed, :createdBy, :createdPerson, :priority, :percentComplete, :startDate, :startDateFormat, :startDateLong, :endDate, :endDateFormat, :endDateLong, :duration, :url, :subtaskUrl, :timesheetUrl, :owners, :comments, :associateDocumentIds, :associateForumIds, :tasks, :tasklist
+				attr_accessor :id, :idString, :name, :completed, :createdBy, :createdPerson, :priority, :percentComplete, :startDate, :startDateFormat, :startDateLong, :endDate, :endDateFormat, :endDateLong, :duration, :url, :subtaskUrl, :timesheetUrl, :owners, :comments, :associateDocumentIds, :associateForumIds, :tasks, :tasklist
 			
 			public
 


### PR DESCRIPTION
This change is to fulfill this prerequisite:

https://apihelp.wiki.zoho.com/Prerequisites.html

> The API key has to be passed as a parameter in every request and is used to make API calls, retrieve data / do specific actions.
